### PR TITLE
Making assert equals strict

### DIFF
--- a/tests/LeftPadTest.php
+++ b/tests/LeftPadTest.php
@@ -11,20 +11,20 @@ class LeftPadTest extends TestCase
     /** @test */
     public function global_function_works_properly(): void
     {
-        $this->assertEquals('  foo', leftpad('foo', 5));
-        $this->assertEquals('foobar', leftpad('foobar', 6));
-        $this->assertEquals('foobar', leftpad('foobar', 3));
-        $this->assertEquals('01', leftpad('1', 2, '0'));
-        $this->assertEquals('-1', leftpad('1', 2, '-'));
+        $this->assertSame('  foo', leftpad('foo', 5));
+        $this->assertSame('foobar', leftpad('foobar', 6));
+        $this->assertSame('foobar', leftpad('foobar', 3));
+        $this->assertSame('01', leftpad('1', 2, '0'));
+        $this->assertSame('-1', leftpad('1', 2, '-'));
     }
 
     /** @test */
     public function namespaced_function_works_properly(): void
     {
-        $this->assertEquals('  foo', \Alexsoft\Leftpad\leftpad('foo', 5));
-        $this->assertEquals('foobar', \Alexsoft\Leftpad\leftpad('foobar', 6));
-        $this->assertEquals('foobar', \Alexsoft\Leftpad\leftpad('foobar', 3));
-        $this->assertEquals('01', \Alexsoft\Leftpad\leftpad('1', 2, '0'));
-        $this->assertEquals('-1', \Alexsoft\Leftpad\leftpad('1', 2, '-'));
+        $this->assertSame('  foo', \Alexsoft\Leftpad\leftpad('foo', 5));
+        $this->assertSame('foobar', \Alexsoft\Leftpad\leftpad('foobar', 6));
+        $this->assertSame('foobar', \Alexsoft\Leftpad\leftpad('foobar', 3));
+        $this->assertSame('01', \Alexsoft\Leftpad\leftpad('1', 2, '0'));
+        $this->assertSame('-1', \Alexsoft\Leftpad\leftpad('1', 2, '-'));
     }
 }


### PR DESCRIPTION
# Changed log

- It can be great to use the `assertSame` to make assert equals strict.